### PR TITLE
Fix: "Webpack watching on Windows"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 import glob from 'glob'
 import compact from 'lodash/compact'
 import uniq from 'lodash/uniq'
+import { resolve as resolvePath } from 'path'
 
 export default class WebpackWatchPlugin {
   constructor ({
@@ -46,6 +47,7 @@ export default class WebpackWatchPlugin {
           return file
         })
       ))
+        .map(file => resolvePath(file))
 
       if (this.verbose && !this.filesAlreadyAdded) {
         console.log('Additional files watched : ', JSON.stringify(files, null, 2))


### PR DESCRIPTION
Try to fix buggy watching on Windows, as describing in Fridus/webpack-watch-files-plugin#6.

I found that it was an issue about path separator used on Windows, i.e. `\\`.
`path.resolve` should be called before files are added to Webpack dependencies.

@Fridus Please review this PR, thank you.

Also as a remind that there quite a lot **audit warnings** there (not fixed in this PR).
Maybe `lodash` should be updated.
