### PR TITLE
Add support for Webpack 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "webpack": "^4.44.1"
   },
   "peerDependencies": {
-    "webpack": "^3 || ^4"
+    "webpack": "^3 || ^4 || ^5"
   }
 }


### PR DESCRIPTION
This package continues to work with Webpack 5, so no code changes are necessary - just removal of a warning at install time.